### PR TITLE
Fix missing source file warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
     "lib": ["es2020", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
Fixes missing file warnings stemming from source map files.

Rel: https://github.com/geostyler/geostyler-style/pull/297