### PR TITLE
Split fill and outline properties in separate symbolizers (refs #214)

### DIFF
--- a/data/mapbox/fill_simple_outline.ts
+++ b/data/mapbox/fill_simple_outline.ts
@@ -2,26 +2,28 @@ const fillSimpleFillOutline: any = {
   version: 8,
   name: 'Simple Fill With outline',
   layers: [{
-      id: 'Simple Fill With outline',
-      type: "fill",
-      paint: {
-        "fill-color": "#ff0000"
-      }
-    },
-    {
-      id: "Simple Fill With outline",
-      type: "line",
-      paint: {
-        "line-opacity": 0.5,
-        "line-color": "#00ff00",
-        "line-width": 2
-      },
-      layout: {
-        "line-cap": "butt",
-        "line-join": "round"
-      }
+    id: 'rule_0',
+    type: 'fill',
+    paint: {
+      'fill-color': '#ff0000'
     }
-  ]
+  },
+  {
+    id: 'rule_0',
+    type: 'line',
+    paint: {
+      'line-opacity': 0.5,
+      'line-color': '#00ff00',
+      'line-width': 2
+    },
+    layout: {
+      'line-cap': 'butt',
+      'line-join': 'round'
+    }
+  }],
+  metadata: {
+    splitIds: ['rule_0']
+  }
 };
 
 export default fillSimpleFillOutline;

--- a/data/mapbox/fill_simple_outline.ts
+++ b/data/mapbox/fill_simple_outline.ts
@@ -1,0 +1,27 @@
+const fillSimpleFillOutline: any = {
+  version: 8,
+  name: 'Simple Fill With outline',
+  layers: [{
+      id: 'Simple Fill With outline',
+      type: "fill",
+      paint: {
+        "fill-color": "#ff0000"
+      }
+    },
+    {
+      id: "Simple Fill With outline",
+      type: "line",
+      paint: {
+        "line-opacity": 0.5,
+        "line-color": "#00ff00",
+        "line-width": 2
+      },
+      layout: {
+        "line-cap": "butt",
+        "line-join": "round"
+      }
+    }
+  ]
+};
+
+export default fillSimpleFillOutline;

--- a/data/styles/fill_simple_outline.ts
+++ b/data/styles/fill_simple_outline.ts
@@ -1,0 +1,19 @@
+import { Style } from 'geostyler-style';
+
+const fillSimpleFillOutline: Style = {
+  name: 'Simple Fill With outline',
+  rules: [{
+    name: 'Simple Fill With outline',
+    symbolizers: [{
+        kind: "Fill",
+        color: "#ff0000",
+        outlineColor: "#00ff00",
+        outlineWidth: 2,
+        outlineOpacity: 0.5,
+        outlineCap: "butt",
+        outlineJoin: "round"
+    }]
+  }]
+};
+
+export default fillSimpleFillOutline;

--- a/data/styles/fill_simple_outline.ts
+++ b/data/styles/fill_simple_outline.ts
@@ -3,15 +3,15 @@ import { Style } from 'geostyler-style';
 const fillSimpleFillOutline: Style = {
   name: 'Simple Fill With outline',
   rules: [{
-    name: 'Simple Fill With outline',
+    name: 'rule_0',
     symbolizers: [{
-        kind: "Fill",
-        color: "#ff0000",
-        outlineColor: "#00ff00",
-        outlineWidth: 2,
-        outlineOpacity: 0.5,
-        outlineCap: "butt",
-        outlineJoin: "round"
+      kind: 'Fill',
+      color: '#ff0000',
+      outlineColor: '#00ff00',
+      outlineWidth: 2,
+      outlineOpacity: 0.5,
+      outlineCap: 'butt',
+      outlineJoin: 'round'
     }]
   }]
 };

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -5,6 +5,8 @@ import line_simpleline from '../data/styles/line_simpleline';
 import mb_line_simpleline from '../data/mapbox/line_simpleline';
 import fill_simplefill from '../data/styles/fill_simplefill';
 import mb_fill_simplefill from '../data/mapbox/fill_simplefill';
+import fill_simplefill_outline from '../data/styles/fill_simple_outline'
+import mb_fill_simplefill_outline from '../data/mapbox/fill_simple_outline'
 import point_simpletext from '../data/styles/point_simpletext';
 import mb_point_simpletext from '../data/mapbox/point_simpletext';
 import point_placeholdertext from '../data/styles/point_placeholderText';
@@ -188,6 +190,13 @@ describe('MapboxStyleParser implements StyleParser', () => {
       const { output: mbStyle } = await styleParser.writeStyle(fill_patternfill);
       expect(mbStyle).toBeDefined();
       expect(JSON.parse(mbStyle!)).toEqual(mb_fill_patternfill);
+    });
+
+    it('can write a mapbox Fill style with outline', async () => {
+      expect.assertions(2);
+      const { output: mbStyle } = await styleParser.writeStyle(fill_simplefill_outline);
+      expect(mbStyle).toBeDefined();
+      expect(JSON.parse(mbStyle!)).toEqual(mb_fill_simplefill_outline);
     });
 
     it('can write a mapbox Text style', async () => {

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -5,8 +5,8 @@ import line_simpleline from '../data/styles/line_simpleline';
 import mb_line_simpleline from '../data/mapbox/line_simpleline';
 import fill_simplefill from '../data/styles/fill_simplefill';
 import mb_fill_simplefill from '../data/mapbox/fill_simplefill';
-import fill_simplefill_outline from '../data/styles/fill_simple_outline'
-import mb_fill_simplefill_outline from '../data/mapbox/fill_simple_outline'
+import fill_simplefill_outline from '../data/styles/fill_simple_outline';
+import mb_fill_simplefill_outline from '../data/mapbox/fill_simple_outline';
 import point_simpletext from '../data/styles/point_simpletext';
 import mb_point_simpletext from '../data/mapbox/point_simpletext';
 import point_placeholdertext from '../data/styles/point_placeholderText';

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -995,6 +995,7 @@ export class MapboxStyleParser implements StyleParser {
           return [fillStyle, outlineStyle];
         } else {
           return [{
+            layerType: 'fill',
             paint : this.getPaintFromFillSymbolizer(symbolizerClone as FillSymbolizer),
             layout : this.getLayoutFromFillSymbolizer(symbolizerClone as FillSymbolizer)
           }];


### PR DESCRIPTION
Co-authored-by: Philippe Prevautel <philippe.prevautel@ign.fr>