### PR TITLE
Change writeStyle to return mapbox style as object instead of string

### DIFF
--- a/data/mapbox/circle_simplecircle.ts
+++ b/data/mapbox/circle_simplecircle.ts
@@ -1,4 +1,6 @@
-const circleSimpleCircle: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const circleSimpleCircle: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Circle',
   layers: [

--- a/data/mapbox/fill_patternfill.ts
+++ b/data/mapbox/fill_patternfill.ts
@@ -1,4 +1,6 @@
-const fillSimpleFill: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const fillSimpleFill: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Pattern Fill',
   sprite: 'https://testurl.com',

--- a/data/mapbox/fill_simple_outline.ts
+++ b/data/mapbox/fill_simple_outline.ts
@@ -1,4 +1,6 @@
-const fillSimpleFillOutline: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const fillSimpleFillOutline: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Fill With outline',
   layers: [{

--- a/data/mapbox/fill_simplefill.ts
+++ b/data/mapbox/fill_simplefill.ts
@@ -1,4 +1,6 @@
-const fillSimpleFill: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const fillSimpleFill: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Fill',
   layers: [

--- a/data/mapbox/icon_simpleicon.ts
+++ b/data/mapbox/icon_simpleicon.ts
@@ -1,4 +1,6 @@
-const iconSimpleIcon: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const iconSimpleIcon: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Icon',
   sprite: 'https://testurl.com',

--- a/data/mapbox/icon_simpleicon_mapboxapi.ts
+++ b/data/mapbox/icon_simpleicon_mapboxapi.ts
@@ -1,4 +1,6 @@
-const iconSimpleIcon: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const iconSimpleIcon: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Icon',
   sprite: 'mapbox://sprites/mapbox/streets-v8',

--- a/data/mapbox/line_patternline.ts
+++ b/data/mapbox/line_patternline.ts
@@ -1,4 +1,6 @@
-const linePatternLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const linePatternLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Pattern Line',
   sprite: 'https://testurl.com',

--- a/data/mapbox/line_simpleline.ts
+++ b/data/mapbox/line_simpleline.ts
@@ -1,4 +1,6 @@
-const lineSimpleLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const lineSimpleLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Line',
   layers: [

--- a/data/mapbox/line_simpleline_basefilter.ts
+++ b/data/mapbox/line_simpleline_basefilter.ts
@@ -1,4 +1,6 @@
-const lineSimpleLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const lineSimpleLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Small populated New Yorks',
   layers: [{

--- a/data/mapbox/line_simpleline_expression.ts
+++ b/data/mapbox/line_simpleline_expression.ts
@@ -1,4 +1,6 @@
-const lineSimpleLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const lineSimpleLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Line Filter',
   layers: [{

--- a/data/mapbox/line_simpleline_zoom.ts
+++ b/data/mapbox/line_simpleline_zoom.ts
@@ -1,4 +1,6 @@
-const lineSimpleLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const lineSimpleLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Line Filter',
   layers: [{

--- a/data/mapbox/multi_rule_line_fill.ts
+++ b/data/mapbox/multi_rule_line_fill.ts
@@ -1,4 +1,6 @@
-const multiRuleLineFill: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const multiRuleLineFill: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Rule Line Fill',
   layers: [

--- a/data/mapbox/multi_simpleline_simplefill.ts
+++ b/data/mapbox/multi_simpleline_simplefill.ts
@@ -1,4 +1,6 @@
-const multiSimpleLineSimpleFill: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const multiSimpleLineSimpleFill: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Line Simple Fill',
   layers: [

--- a/data/mapbox/point_placeholderText.ts
+++ b/data/mapbox/point_placeholderText.ts
@@ -1,4 +1,6 @@
-const pointPlaceholderText: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const pointPlaceholderText: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Placeholder Text',
   layers: [

--- a/data/mapbox/point_placeholderText_simple.ts
+++ b/data/mapbox/point_placeholderText_simple.ts
@@ -1,4 +1,6 @@
-const pointPlaceholderText: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const pointPlaceholderText: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Placeholder Text',
   layers: [

--- a/data/mapbox/point_simpletext.ts
+++ b/data/mapbox/point_simpletext.ts
@@ -1,4 +1,6 @@
-const pointSimpleText: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const pointSimpleText: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Text',
   layers: [

--- a/data/mapbox_metadata/circle_simplecircle.ts
+++ b/data/mapbox_metadata/circle_simplecircle.ts
@@ -1,4 +1,6 @@
-const circleSimpleCircle: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const circleSimpleCircle: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Circle',
   layers: [

--- a/data/mapbox_metadata/fill_patternfill.ts
+++ b/data/mapbox_metadata/fill_patternfill.ts
@@ -1,4 +1,6 @@
-const fillSimpleFill: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const fillSimpleFill: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Pattern Fill',
   sprite: 'https://testurl.com',

--- a/data/mapbox_metadata/fill_simple_outline.ts
+++ b/data/mapbox_metadata/fill_simple_outline.ts
@@ -1,4 +1,6 @@
-const fillSimpleFillOutline: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const fillSimpleFillOutline: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Fill With outline',
   layers: [{

--- a/data/mapbox_metadata/fill_simplefill.ts
+++ b/data/mapbox_metadata/fill_simplefill.ts
@@ -1,4 +1,6 @@
-const fillSimpleFill: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const fillSimpleFill: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Fill',
   layers: [

--- a/data/mapbox_metadata/icon_simpleicon.ts
+++ b/data/mapbox_metadata/icon_simpleicon.ts
@@ -1,4 +1,6 @@
-const iconSimpleIcon: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const iconSimpleIcon: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Icon',
   sprite: 'https://testurl.com',

--- a/data/mapbox_metadata/icon_simpleicon_mapboxapi.ts
+++ b/data/mapbox_metadata/icon_simpleicon_mapboxapi.ts
@@ -1,4 +1,6 @@
-const iconSimpleIcon: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const iconSimpleIcon: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Icon',
   sprite: 'mapbox://sprites/mapbox/streets-v8',

--- a/data/mapbox_metadata/line_patternline.ts
+++ b/data/mapbox_metadata/line_patternline.ts
@@ -1,4 +1,6 @@
-const linePatternLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const linePatternLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Pattern Line',
   sprite: 'https://testurl.com',

--- a/data/mapbox_metadata/line_simpleline.ts
+++ b/data/mapbox_metadata/line_simpleline.ts
@@ -1,4 +1,6 @@
-const lineSimpleLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const lineSimpleLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Line',
   layers: [

--- a/data/mapbox_metadata/line_simpleline_basefilter.ts
+++ b/data/mapbox_metadata/line_simpleline_basefilter.ts
@@ -1,4 +1,6 @@
-const lineSimpleLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const lineSimpleLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Small populated New Yorks',
   layers: [{

--- a/data/mapbox_metadata/line_simpleline_expression.ts
+++ b/data/mapbox_metadata/line_simpleline_expression.ts
@@ -1,4 +1,6 @@
-const lineSimpleLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const lineSimpleLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Line Filter',
   layers: [{

--- a/data/mapbox_metadata/line_simpleline_zoom.ts
+++ b/data/mapbox_metadata/line_simpleline_zoom.ts
@@ -1,4 +1,6 @@
-const lineSimpleLine: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const lineSimpleLine: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Line Filter',
   layers: [{

--- a/data/mapbox_metadata/multi_rule_line_fill.ts
+++ b/data/mapbox_metadata/multi_rule_line_fill.ts
@@ -1,4 +1,6 @@
-const multiRuleLineFill: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const multiRuleLineFill: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Rule Line Fill',
   layers: [

--- a/data/mapbox_metadata/multi_simpleline_simplefill.ts
+++ b/data/mapbox_metadata/multi_simpleline_simplefill.ts
@@ -1,4 +1,6 @@
-const multiSimpleLineSimpleFill: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const multiSimpleLineSimpleFill: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Line Simple Fill',
   layers: [

--- a/data/mapbox_metadata/point_placeholderText.ts
+++ b/data/mapbox_metadata/point_placeholderText.ts
@@ -1,4 +1,6 @@
-const pointPlaceholderText: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const pointPlaceholderText: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Placeholder Text',
   layers: [

--- a/data/mapbox_metadata/point_placeholderText_simple.ts
+++ b/data/mapbox_metadata/point_placeholderText_simple.ts
@@ -1,4 +1,6 @@
-const pointPlaceholderText: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const pointPlaceholderText: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Placeholder Text',
   layers: [

--- a/data/mapbox_metadata/point_simpletext.ts
+++ b/data/mapbox_metadata/point_simpletext.ts
@@ -1,4 +1,6 @@
-const pointSimpleText: any = {
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const pointSimpleText: Omit<MbStyle, 'sources'> = {
   version: 8,
   name: 'Simple Text',
   layers: [

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -48,6 +48,8 @@ import mb_line_patternline_metadata from '../data/mapbox_metadata/line_patternli
 import point_placeholdertext_simple from '../data/styles/point_placeholderText_simple';
 import mb_point_placeholdertext_simple from '../data/mapbox/point_placeholderText_simple';
 import mb_point_placeholdertext_simple_metadata from '../data/mapbox_metadata/point_placeholderText_simple';
+import { CustomLayerInterface } from 'mapbox-gl';
+import { AnyLayer } from 'mapbox-gl';
 
 it('MapboxStyleParser is defined', () => {
   expect(MapboxStyleParser).toBeDefined();
@@ -126,7 +128,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
     it('can write and read a mapbox style with min and max zoom', async () => {
       expect.assertions(3);
       const { output: mbStyle } = await styleParser.writeStyle(line_simpleline_zoom);
-      const { output: geoStylerStyle } = await styleParser.readStyle(JSON.parse(mbStyle!));
+      const { output: geoStylerStyle } = await styleParser.readStyle(mbStyle!);
       expect(geoStylerStyle).toBeDefined();
       const min = geoStylerStyle?.rules[0].scaleDenominator?.min;
       const max = geoStylerStyle?.rules[0].scaleDenominator?.max;
@@ -191,100 +193,100 @@ describe('MapboxStyleParser implements StyleParser', () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(line_simpleline);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle as string)).toEqual(mb_line_simpleline_metadata);
+      expect(mbStyle).toEqual(mb_line_simpleline_metadata);
     });
 
     it('can write a mapbox Line style with fill pattern', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(line_patternline);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_line_patternline_metadata);
+      expect(mbStyle).toEqual(mb_line_patternline_metadata);
     });
 
     it('can write a mapbox Fill style', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(fill_simplefill);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_fill_simplefill_metadata);
+      expect(mbStyle).toEqual(mb_fill_simplefill_metadata);
     });
 
     it('can write a mapbox Fill style with fill pattern', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(fill_patternfill);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_fill_patternfill_metadata);
+      expect(mbStyle).toEqual(mb_fill_patternfill_metadata);
     });
 
     it('can write a mapbox Fill style with outline', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(fill_simplefill_outline);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_fill_simplefill_outline_metadata);
+      expect(mbStyle).toEqual(mb_fill_simplefill_outline_metadata);
     });
 
     it('can write a mapbox Text style', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(point_simpletext);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_point_simpletext_metadata);
+      expect(mbStyle).toEqual(mb_point_simpletext_metadata);
     });
 
     it('can write a mapbox Text style with a placeholder Text', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(point_placeholdertext_simple);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_point_placeholdertext_simple_metadata);
+      expect(mbStyle).toEqual(mb_point_placeholdertext_simple_metadata);
     });
 
     it('can write a mapbox Circle style', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(circle_simplecircle);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_circle_simplecircle_metadata);
+      expect(mbStyle).toEqual(mb_circle_simplecircle_metadata);
     });
 
     it('can write a mapbox style with multiple symbolizers', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(multi_simpleline_simplefill);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_multi_simpleline_simplefill_metadata);
+      expect(mbStyle).toEqual(mb_multi_simpleline_simplefill_metadata);
     });
 
     it('can write a mapbox style with multiple rules', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(multi_rule_line_fill);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_multi_rule_line_fill_metadata);
+      expect(mbStyle).toEqual(mb_multi_rule_line_fill_metadata);
     });
 
     it('can write a mapbox style with a complex filter', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(line_simpleline_basefilter);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_line_simpleline_basefilter_metadata);
+      expect(mbStyle).toEqual(mb_line_simpleline_basefilter_metadata);
     });
 
     it('can write a mapbox style with min and max zoom', async () => {
       expect.assertions(3);
       const { output: mbStyle } = await styleParser.writeStyle(line_simpleline_zoom);
       expect(mbStyle).toBeDefined();
-      const parsedMbStyle = JSON.parse(mbStyle!);
-      expect(parsedMbStyle.layers[0].minzoom).toBeCloseTo(mb_line_simpleline_zoom_metadata.layers[0].minzoom, 0);
-      expect(parsedMbStyle.layers[0].maxzoom).toBeCloseTo(mb_line_simpleline_zoom_metadata.layers[0].maxzoom, 0);
+      const layer = mbStyle?.layers?.[0] as Exclude<AnyLayer, CustomLayerInterface>;
+      expect(layer.minzoom).toBeCloseTo(mb_line_simpleline_zoom_metadata.layers[0].minzoom, 0);
+      expect(layer.maxzoom).toBeCloseTo(mb_line_simpleline_zoom_metadata.layers[0].maxzoom, 0);
     });
 
     it('can write a mapbox style with an icon', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(icon_simpleicon);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_icon_simpleicon_metadata);
+      expect(mbStyle).toEqual(mb_icon_simpleicon_metadata);
     });
 
     it('can write a mapbox style with an icon and resolves mapbox api', async () => {
       expect.assertions(2);
       const { output: mbStyle } = await styleParser.writeStyle(icon_simpleicon_mapboxapi);
       expect(mbStyle).toBeDefined();
-      expect(JSON.parse(mbStyle!)).toEqual(mb_icon_simpleicon_mapboxapi_metadata);
+      expect(mbStyle).toEqual(mb_icon_simpleicon_mapboxapi_metadata);
     });
   });
 });

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -271,8 +271,9 @@ describe('MapboxStyleParser implements StyleParser', () => {
       const { output: mbStyle } = await styleParser.writeStyle(line_simpleline_zoom);
       expect(mbStyle).toBeDefined();
       const layer = mbStyle?.layers?.[0] as Exclude<AnyLayer, CustomLayerInterface>;
-      expect(layer.minzoom).toBeCloseTo(mb_line_simpleline_zoom_metadata.layers[0].minzoom, 0);
-      expect(layer.maxzoom).toBeCloseTo(mb_line_simpleline_zoom_metadata.layers[0].maxzoom, 0);
+      const mbLayers = mb_line_simpleline_zoom_metadata.layers as (Exclude<AnyLayer, CustomLayerInterface>)[];
+      expect(layer.minzoom).toBeCloseTo(mbLayers[0].minzoom!, 0);
+      expect(layer.maxzoom).toBeCloseTo(mbLayers[0].maxzoom!, 0);
     });
 
     it('can write a mapbox style with an icon', async () => {

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -44,8 +44,15 @@ import {
   LinePaint,
   SymbolLayout,
   SymbolPaint,
-  Style as MbStyle
+  Style as MapboxStyle,
+  Sources
 } from 'mapbox-gl';
+
+/**
+ * The style representation of mapbox-gl but with optional sources, as these are
+ * not required for reading the style and get stripped when writing.
+ */
+export type MbStyle = Omit<MapboxStyle, 'sources'> & { sources?: Sources };
 
 type NoneCustomLayer = Exclude<AnyLayer, CustomLayerInterface>;
 
@@ -865,7 +872,7 @@ export class MapboxStyleParser implements StyleParser<Omit<MbStyle, 'sources'>> 
    * @param mapboxStyle The Mapbox Style object
    * @return A GeoStylerStyle-Style
    */
-  mapboxStyleToGeoStylerStyle(mapboxStyle: MbStyle): Style {
+  mapboxStyleToGeoStylerStyle(mapboxStyle: Omit<MbStyle, 'sources'>): Style {
     if (!(mapboxStyle instanceof Object)) {
       mapboxStyle = JSON.parse(mapboxStyle);
     }
@@ -895,7 +902,7 @@ export class MapboxStyleParser implements StyleParser<Omit<MbStyle, 'sources'>> 
    * @param mapboxStyle The Mapbox Style object
    * @return The Promise resolving with a GeoStylerStyle-ReadStyleResult
    */
-  readStyle(mapboxStyle: MbStyle): Promise<ReadStyleResult> {
+  readStyle(mapboxStyle: Omit<MbStyle, 'sources'>): Promise<ReadStyleResult> {
     return new Promise<ReadStyleResult>(resolve => {
       try {
         const mbStyle = _cloneDeep(mapboxStyle);

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -75,7 +75,7 @@ type OptionsType = {
     pretty?: boolean;
 };
 
-export class MapboxStyleParser implements StyleParser<MbStyle> {
+export class MapboxStyleParser implements StyleParser<Omit<MbStyle, 'sources'>> {
 
   // looks like there's no way to access static properties from an instance
   // without a reference to the constructor function, so we have to duplicate
@@ -918,12 +918,12 @@ export class MapboxStyleParser implements StyleParser<MbStyle> {
    * @param geoStylerStyle A GeoStylerStyle-Style
    * @return The Promise resolving with a GeoStylerStyle-WriteStyleResult
    */
-  writeStyle(geoStylerStyle: Style): Promise<WriteStyleResult<MbStyle>> {
-    return new Promise<WriteStyleResult<MbStyle>>(resolve => {
+  writeStyle(geoStylerStyle: Style): Promise<WriteStyleResult<Omit<MbStyle, 'sources'>>> {
+    return new Promise<WriteStyleResult<Omit<MbStyle, 'sources'>>>(resolve => {
       const unsupportedProperties = this.checkForUnsupportedProperties(geoStylerStyle);
       try {
         const gsStyle = _cloneDeep(geoStylerStyle);
-        const output: any = this.geoStylerStyleToMapboxObject(gsStyle);
+        const output: Omit<MbStyle, 'sources'> = this.geoStylerStyleToMapboxObject(gsStyle);
         resolve({
           output,
           unsupportedProperties,

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -75,7 +75,7 @@ type OptionsType = {
     pretty?: boolean;
 };
 
-export class MapboxStyleParser implements StyleParser {
+export class MapboxStyleParser implements StyleParser<MbStyle> {
 
   // looks like there's no way to access static properties from an instance
   // without a reference to the constructor function, so we have to duplicate
@@ -918,15 +918,12 @@ export class MapboxStyleParser implements StyleParser {
    * @param geoStylerStyle A GeoStylerStyle-Style
    * @return The Promise resolving with a GeoStylerStyle-WriteStyleResult
    */
-  writeStyle(geoStylerStyle: Style): Promise<WriteStyleResult<string>> {
-    return new Promise<WriteStyleResult<string>>(resolve => {
+  writeStyle(geoStylerStyle: Style): Promise<WriteStyleResult<MbStyle>> {
+    return new Promise<WriteStyleResult<MbStyle>>(resolve => {
       const unsupportedProperties = this.checkForUnsupportedProperties(geoStylerStyle);
       try {
         const gsStyle = _cloneDeep(geoStylerStyle);
-        const mapboxStyle: any = this.geoStylerStyleToMapboxObject(gsStyle);
-        const output = this.pretty
-          ? JSON.stringify(mapboxStyle, null, 2)
-          : JSON.stringify(mapboxStyle);
+        const output: any = this.geoStylerStyleToMapboxObject(gsStyle);
         resolve({
           output,
           unsupportedProperties,


### PR DESCRIPTION
This transforms the WriteStyleResult `output` to be a mapbox style as a javascript object instead of a string.

This is obviously a breaking change. :)