### PR TITLE
fix: merge icontext symbol from separate symbolizers when needed

### DIFF
--- a/data/mapbox/icontext_symbolizer.ts
+++ b/data/mapbox/icontext_symbolizer.ts
@@ -1,0 +1,25 @@
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const iconTextSymbolizer: Omit<MbStyle, 'sources'> = {
+  version: 8,
+  name: 'icontext symbolizer',
+  sprite: 'https://testurl.com',
+  layers: [
+    {
+      type: 'symbol',
+      paint: {
+        'text-color': 'rgba(45, 45, 45, 1)',
+      },
+      layout: {
+        'text-field': '{name}',
+        'text-size': 12,
+        'icon-image': 'poi',
+        visibility: 'visible',
+      },
+      id: 'label and icon',
+    }
+  ]
+};
+
+
+export default iconTextSymbolizer;

--- a/data/mapbox_metadata/icontext_symbolizer.ts
+++ b/data/mapbox_metadata/icontext_symbolizer.ts
@@ -1,0 +1,38 @@
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const iconTextSymbolizer: Omit<MbStyle, 'sources'> = {
+  version: 8,
+  name: 'icontext symbolizer',
+  sprite: 'https://testurl.com',
+  layers: [
+    {
+      type: 'symbol',
+      paint: {
+        'text-color': 'rgba(45, 45, 45, 1)',
+      },
+      layout: {
+        'text-field': '{name}',
+        'text-size': 12,
+        'icon-image': 'poi',
+        visibility: 'visible',
+      },
+      id: 'r0_sy0_st0',
+    }
+  ],
+  metadata: {
+    'geostyler:ref': {
+      rules: [
+        {
+          name: 'label and icon',
+          symbolizers: [
+            [
+              'r0_sy0_st0',
+            ]
+          ],
+        },
+      ],
+    },
+  },
+};
+
+export default iconTextSymbolizer;

--- a/data/styles_metadata/icontext_symbolizer.ts
+++ b/data/styles_metadata/icontext_symbolizer.ts
@@ -1,0 +1,34 @@
+import { Style } from 'geostyler-style';
+
+const iconTextSymbolizer: Style = {
+  name: 'icontext symbolizer',
+  rules: [
+    {
+      name: 'label and icon',
+      symbolizers: [
+        {
+          kind: 'Text',
+          color: 'rgba(45, 45, 45, 1)',
+          label: '{{name}}',
+          size: 12,
+          visibility: true
+        },
+        {
+          kind: 'Icon',
+          visibility: true,
+          image: '/sprites/?name=poi&baseurl=' + encodeURIComponent('https://testurl.com')
+        }
+      ]
+    }
+  ],
+  metadata: {
+    'mapbox:ref': {
+      splitSymbolizers: [{
+        rule: 0,
+        symbolizers: [0, 1]
+      }]
+    }
+  }
+};
+
+export default iconTextSymbolizer;

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -48,6 +48,9 @@ import mb_line_patternline_metadata from '../data/mapbox_metadata/line_patternli
 import point_placeholdertext_simple from '../data/styles/point_placeholderText_simple';
 import mb_point_placeholdertext_simple from '../data/mapbox/point_placeholderText_simple';
 import mb_point_placeholdertext_simple_metadata from '../data/mapbox_metadata/point_placeholderText_simple';
+import icontext_symbolizer_metadata from '../data/styles_metadata/icontext_symbolizer';
+import mb_icontext_symbolizer from '../data/mapbox/icontext_symbolizer';
+import mb_icontext_symbolizer_metadata from '../data/mapbox_metadata/icontext_symbolizer';
 import { CustomLayerInterface } from 'mapbox-gl';
 import { AnyLayer } from 'mapbox-gl';
 
@@ -186,6 +189,12 @@ describe('MapboxStyleParser implements StyleParser', () => {
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(icon_simpleicon_mapboxapi);
     });
+
+    it('can read a mapbox style with icontext symbolizer', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(mb_icontext_symbolizer);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(icontext_symbolizer_metadata);
+    });
   });
 
   describe('#writeStyle', () => {
@@ -288,6 +297,12 @@ describe('MapboxStyleParser implements StyleParser', () => {
       const { output: mbStyle } = await styleParser.writeStyle(icon_simpleicon_mapboxapi);
       expect(mbStyle).toBeDefined();
       expect(mbStyle).toEqual(mb_icon_simpleicon_mapboxapi_metadata);
+    });
+
+    it('can write a mapbox style with icontext symbolizer', async () => {
+      const { output: mbStyle } = await styleParser.writeStyle(icontext_symbolizer_metadata);
+      expect(mbStyle).toBeDefined();
+      expect(mbStyle).toEqual(mb_icontext_symbolizer_metadata);
     });
   });
 });

--- a/src/Util/MapboxStyleUtil.ts
+++ b/src/Util/MapboxStyleUtil.ts
@@ -108,7 +108,7 @@ class MapboxStyleUtil {
   // TODO: TextSymbolizer can be removed once it is fixed in the geostyler-style
   public static symbolizerAllUndefined(symbolizer: Symbolizer | TextSymbolizer): boolean {
     return !Object.keys(symbolizer)
-      .filter(val => val !== 'kind')
+      .filter(val => val !== 'kind' && val !== 'visibility')
       .some((val: keyof Symbolizer) => typeof symbolizer[val] !== 'undefined');
   }
 


### PR DESCRIPTION
This merges geostyler icon and text symbolizers of a rule, if they were based on a single mapbox layer with type `symbol` and icon and text properties.

To do so, the new `metadata` block of the geostyler style was used. There, we keep track of split up mapbox layers so they can be merged when parsing again. 