### PR TITLE
Track sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,54 +12,12 @@ The endpoint MUST return a reference to a single image.
 
 ---
 
-Mapbox Styles require the properties [`sources`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#root-sources) (root property) and [`source`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layer-source) (layers property). geostyler-mapbox-parser only parses style related properties to keep a clear separation between style and data. Thus, `sources` and `source` have to be added to the created styleobject after parsing, manually. See code snippet below for an example implementation of a wrapper function.
-
-```javascript
-/**
- * Example wrapper function that maps a source to the corresponding
- * layer based on layer id. Expects a mapper object with key value
- * pairs in the format of "layerId:'sourceName'".
-**/
-function wrapper(sources, mapper, style) {
-  if (typeof style === 'undefined') {
-    return;
-  }
-  if (typeof mapper === 'undefined') {
-    return style;
-  }
-  if (typeof sources === 'undefined') {
-    return style;
-  }
-
-  style.sources = sources;
-  style.layers.forEach(l => {
-    l.source = mapper[l.id];
-  });
-  return style;
-}
-
-// required mapper object where the key refers to the layer id
-// and the value to the source name.
-var mapper = {
-  "water": "mapbox-streets"
-};
-
-// mapbox sources object
-var sources = {
-  "mapbox-streets": {
-    "type": "vector",
-    "url": "mapbox://mapbox.mapbox-streets-v6"
-  }
-};
-
-// mapbox style object
-var mbStyle = {
-  version: 8,
-  layers: [...]
-};
-
-var wrappedStyle = wrapper(sources, mapper, style);
-```
+Mapbox styles require the properties [`sources`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#root-sources) (root property)
+and [`source`](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layer-source) (layers property).
+In order to keep a clear separation between style and data, geostyler-mapbox-parser puts the source-related attributes into the metadata block of
+a geostyler-style under `mapbox:ref`. There, the original sources object, as well as the mappings between layers and sources will be stored
+(properties `sources`, `sourceMapping` and `layerSourceMapping`). Applications can then use these mappings for re-creating the same layer structure
+using their map library of choice (e.g. OpenLayers, etc.).
 
 ### How to use
 

--- a/data/mapbox/circle_simplecircle.ts
+++ b/data/mapbox/circle_simplecircle.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const circleSimpleCircle: Omit<MbStyle, 'sources'> = {
+const circleSimpleCircle: MbStyle = {
   version: 8,
   name: 'Simple Circle',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Simple Circle',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': '#000000',

--- a/data/mapbox/expression_case.ts
+++ b/data/mapbox/expression_case.ts
@@ -1,13 +1,20 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const expression_case: Omit<MbStyle, 'sources'> = {
+const expression_case: MbStyle = {
   version: 8,
   name: 'Expression Case',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'earthquake_circle',
       type: 'circle',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'circle-color': [
           'case',

--- a/data/mapbox/expression_get.ts
+++ b/data/mapbox/expression_get.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const expression_get: Omit<MbStyle, 'sources'> = {
+const expression_get: MbStyle = {
   version: 8,
   name: 'Expression Get',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Expression Get',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': '#000000',

--- a/data/mapbox/fill_patternfill.ts
+++ b/data/mapbox/fill_patternfill.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const fillSimpleFill: Omit<MbStyle, 'sources'> = {
+const fillSimpleFill: MbStyle = {
   version: 8,
   name: 'Pattern Fill',
   sprite: 'https://testurl.com',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Pattern Fill',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'fill',
       paint: {
         'fill-color': '#000000',

--- a/data/mapbox/fill_simple_outline.ts
+++ b/data/mapbox/fill_simple_outline.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const fillSimpleFillOutline: Omit<MbStyle, 'sources'> = {
+const fillSimpleFillOutline: MbStyle = {
   version: 8,
   name: 'Simple Fill With outline',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [{
     id: 'r0_sy0_st0',
     type: 'fill',
+    source: 'testsource',
+    'source-layer': 'foo',
     paint: {
       'fill-color': '#ff0000'
     }
@@ -13,6 +20,8 @@ const fillSimpleFillOutline: Omit<MbStyle, 'sources'> = {
   {
     id: 'r0_sy0_st1',
     type: 'line',
+    source: 'testsource',
+    'source-layer': 'foo',
     paint: {
       'line-opacity': 0.5,
       'line-color': '#00ff00',

--- a/data/mapbox/fill_simplefill.ts
+++ b/data/mapbox/fill_simplefill.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const fillSimpleFill: Omit<MbStyle, 'sources'> = {
+const fillSimpleFill: MbStyle = {
   version: 8,
   name: 'Simple Fill',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Simple Fill',
       type: 'fill',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'fill-color': '#000000',
         'fill-opacity': 1

--- a/data/mapbox/icon_simpleicon.ts
+++ b/data/mapbox/icon_simpleicon.ts
@@ -1,13 +1,20 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const iconSimpleIcon: Omit<MbStyle, 'sources'> = {
+const iconSimpleIcon: MbStyle = {
   version: 8,
   name: 'Simple Icon',
   sprite: 'https://testurl.com',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Simple Icon',
       type: 'symbol',
+      source: 'testsource',
+      'source-layer': 'foo',
       layout: {
         'icon-image': 'poi'
       }

--- a/data/mapbox/icon_simpleicon_mapboxapi.ts
+++ b/data/mapbox/icon_simpleicon_mapboxapi.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const iconSimpleIcon: Omit<MbStyle, 'sources'> = {
+const iconSimpleIcon: MbStyle = {
   version: 8,
   name: 'Simple Icon',
   sprite: 'mapbox://sprites/mapbox/streets-v8',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Simple Icon',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'icon-image': 'poi'

--- a/data/mapbox/icontext_symbolizer.ts
+++ b/data/mapbox/icontext_symbolizer.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const iconTextSymbolizer: Omit<MbStyle, 'sources'> = {
+const iconTextSymbolizer: MbStyle = {
   version: 8,
   name: 'icontext symbolizer',
   sprite: 'https://testurl.com',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       type: 'symbol',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'text-color': 'rgba(45, 45, 45, 1)',
       },

--- a/data/mapbox/line_patternline.ts
+++ b/data/mapbox/line_patternline.ts
@@ -1,13 +1,20 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const linePatternLine: Omit<MbStyle, 'sources'> = {
+const linePatternLine: MbStyle = {
   version: 8,
   name: 'Pattern Line',
   sprite: 'https://testurl.com',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Pattern Line',
       type: 'line',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'line-color': '#000000',
         'line-width': 3,

--- a/data/mapbox/line_simpleline.ts
+++ b/data/mapbox/line_simpleline.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const lineSimpleLine: Omit<MbStyle, 'sources'> = {
+const lineSimpleLine: MbStyle = {
   version: 8,
   name: 'Simple Line',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Simple Line',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'line',
       paint: {
         'line-color': '#000000',

--- a/data/mapbox/line_simpleline_basefilter.ts
+++ b/data/mapbox/line_simpleline_basefilter.ts
@@ -1,10 +1,17 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const lineSimpleLine: Omit<MbStyle, 'sources'> = {
+const lineSimpleLine: MbStyle = {
   version: 8,
   name: 'Small populated New Yorks',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [{
     id: 'Small populated New Yorks',
+    source: 'testsource',
+    'source-layer': 'foo',
     type: 'line',
     filter: ['all',
       ['==', 'NAME', 'New York'],

--- a/data/mapbox/line_simpleline_expression.ts
+++ b/data/mapbox/line_simpleline_expression.ts
@@ -1,10 +1,17 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const lineSimpleLine: Omit<MbStyle, 'sources'> = {
+const lineSimpleLine: MbStyle = {
   version: 8,
   name: 'Simple Line Filter',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [{
     id: 'Small populated New Yorks',
+    source: 'testsource',
+    'source-layer': 'foo',
     type: 'line',
     paint: {
       'line-color': '#FF0000',

--- a/data/mapbox/line_simpleline_zoom.ts
+++ b/data/mapbox/line_simpleline_zoom.ts
@@ -1,10 +1,17 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const lineSimpleLine: Omit<MbStyle, 'sources'> = {
+const lineSimpleLine: MbStyle = {
   version: 8,
   name: 'Simple Line Filter',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [{
     id: 'Small populated New Yorks',
+    source: 'testsource',
+    'source-layer': 'foo',
     type: 'line',
     minzoom: 5.5,
     maxzoom: 10,

--- a/data/mapbox/multi_rule_line_fill.ts
+++ b/data/mapbox/multi_rule_line_fill.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const multiRuleLineFill: Omit<MbStyle, 'sources'> = {
+const multiRuleLineFill: MbStyle = {
   version: 8,
   name: 'Rule Line Fill',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Line Rule',
       type: 'line',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'line-color': '#000000',
         'line-width': 3,
@@ -19,6 +26,8 @@ const multiRuleLineFill: Omit<MbStyle, 'sources'> = {
     }, {
       id: 'Fill Rule',
       type: 'fill',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'fill-color': '#000000',
         'fill-opacity': 1

--- a/data/mapbox/multi_simpleline_simplefill.ts
+++ b/data/mapbox/multi_simpleline_simplefill.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const multiSimpleLineSimpleFill: Omit<MbStyle, 'sources'> = {
+const multiSimpleLineSimpleFill: MbStyle = {
   version: 8,
   name: 'Simple Line Simple Fill',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Simple Line Simple Fill',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'line',
       paint: {
         'line-color': '#000000',
@@ -18,6 +25,8 @@ const multiSimpleLineSimpleFill: Omit<MbStyle, 'sources'> = {
       }
     }, {
       id: 'Simple Line Simple Fill',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'fill',
       paint: {
         'fill-color': '#000000',

--- a/data/mapbox/point_placeholderText.ts
+++ b/data/mapbox/point_placeholderText.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const pointPlaceholderText: Omit<MbStyle, 'sources'> = {
+const pointPlaceholderText: MbStyle = {
   version: 8,
   name: 'Placeholder Text',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Placeholder Text',
       type: 'symbol',
+      source: 'testsource',
+      'source-layer': 'foo',
       layout: {
         'text-field': ['format',
           'Area: ', {},

--- a/data/mapbox/point_placeholderText_simple.ts
+++ b/data/mapbox/point_placeholderText_simple.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const pointPlaceholderText: Omit<MbStyle, 'sources'> = {
+const pointPlaceholderText: MbStyle = {
   version: 8,
   name: 'Placeholder Text',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Placeholder Text',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'text-field': '{River}'

--- a/data/mapbox/point_simpletext.ts
+++ b/data/mapbox/point_simpletext.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const pointSimpleText: Omit<MbStyle, 'sources'> = {
+const pointSimpleText: MbStyle = {
   version: 8,
   name: 'Simple Text',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'Simple Text',
       type: 'symbol',
+      source: 'testsource',
+      'source-layer': 'foo',
       layout: {
         'text-field': 'River'
       },

--- a/data/mapbox/source_layer_mapping.ts
+++ b/data/mapbox/source_layer_mapping.ts
@@ -1,0 +1,43 @@
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const sourceLayerMapping: MbStyle = {
+  version: 8,
+  name: 'SourceLayerMapping',
+  sources: {
+    first: {
+      type: 'vector'
+    }
+  },
+  layers: [
+    {
+      id: 'Simple Circle 1',
+      source: 'first',
+      'source-layer': 'foo',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    },
+    {
+      id: 'Simple Circle 2',
+      source: 'first',
+      'source-layer': 'bar',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    }
+  ]
+};
+
+export default sourceLayerMapping;

--- a/data/mapbox/source_mapping.ts
+++ b/data/mapbox/source_mapping.ts
@@ -1,0 +1,46 @@
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const sourceMapping: MbStyle = {
+  version: 8,
+  name: 'SourceMapping',
+  sources: {
+    first: {
+      type: 'vector'
+    },
+    second: {
+      type: 'vector'
+    }
+  },
+  layers: [
+    {
+      id: 'Simple Circle 1',
+      source: 'first',
+      'source-layer': 'foo',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    },
+    {
+      id: 'Simple Circle 2',
+      source: 'second',
+      'source-layer': 'foo',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    }
+  ]
+};
+
+export default sourceMapping;

--- a/data/mapbox_metadata/circle_simplecircle.ts
+++ b/data/mapbox_metadata/circle_simplecircle.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const circleSimpleCircle: Omit<MbStyle, 'sources'> = {
+const circleSimpleCircle: MbStyle = {
   version: 8,
   name: 'Simple Circle',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': '#000000',

--- a/data/mapbox_metadata/expression_case.ts
+++ b/data/mapbox_metadata/expression_case.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const expression_case: Omit<MbStyle, 'sources'> = {
+const expression_case: MbStyle = {
   version: 8,
   name: 'Expression Case',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [

--- a/data/mapbox_metadata/expression_decisions.ts
+++ b/data/mapbox_metadata/expression_decisions.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const expression_decisions: Omit<MbStyle, 'sources'> = {
+const expression_decisions: MbStyle = {
   version: 8,
   name: 'Expression Decisions',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [
@@ -19,6 +26,8 @@ const expression_decisions: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r1_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [
@@ -31,6 +40,8 @@ const expression_decisions: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r2_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [
@@ -43,6 +54,8 @@ const expression_decisions: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r3_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [
@@ -55,6 +68,8 @@ const expression_decisions: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r4_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [
@@ -67,6 +82,8 @@ const expression_decisions: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r5_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [
@@ -79,6 +96,8 @@ const expression_decisions: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r6_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [
@@ -91,6 +110,8 @@ const expression_decisions: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r7_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [
@@ -106,6 +127,8 @@ const expression_decisions: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r8_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': [

--- a/data/mapbox_metadata/expression_get.ts
+++ b/data/mapbox_metadata/expression_get.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const expression_get: Omit<MbStyle, 'sources'> = {
+const expression_get: MbStyle = {
   version: 8,
   name: 'Expression Get',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-color': '#000000',

--- a/data/mapbox_metadata/expression_lookup.ts
+++ b/data/mapbox_metadata/expression_lookup.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const expression_lookup: Omit<MbStyle, 'sources'> = {
+const expression_lookup: MbStyle = {
   version: 8,
   name: 'Expression Lookup',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['length', 'peter']
@@ -14,6 +21,8 @@ const expression_lookup: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r1_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'text-field': ['slice', 'peter', 0, 2]

--- a/data/mapbox_metadata/expression_math.ts
+++ b/data/mapbox_metadata/expression_math.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const expression_math: Omit<MbStyle, 'sources'> = {
+const expression_math: MbStyle = {
   version: 8,
   name: 'Expression Math',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['+', 13, 3, 7]
@@ -14,6 +21,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r1_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['abs', -12]
@@ -21,6 +30,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r2_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['acos', 4]
@@ -28,6 +39,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r3_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['asin', 4]
@@ -35,6 +48,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r4_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['atan', 4]
@@ -42,6 +57,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r5_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['ceil', 3.4]
@@ -49,6 +66,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r6_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['cos', 3.4]
@@ -56,6 +75,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r7_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['/', 100, 2]
@@ -63,6 +84,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r8_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['e']
@@ -70,6 +93,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r9_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['floor', 3.5]
@@ -77,6 +102,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r10_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['ln', 4.6]
@@ -84,6 +111,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r11_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['max', 13, 37, 0, 8, 15]
@@ -91,6 +120,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r12_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['min', 13, 37, 0, 8, 15]
@@ -98,6 +129,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r13_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['%', 3, 2]
@@ -105,6 +138,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r14_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['*', 2, 2.5, 10]
@@ -112,6 +147,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r15_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['pi']
@@ -119,6 +156,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r16_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['^', 2, 4]
@@ -126,6 +165,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r17_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['round', 13.37]
@@ -133,6 +174,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r18_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['sin', 1]
@@ -140,6 +183,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r19_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['sqrt', 1]
@@ -147,6 +192,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r20_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['-', 5, 6]
@@ -154,6 +201,8 @@ const expression_math: Omit<MbStyle, 'sources'> = {
     },
     {
       id: 'r21_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'circle',
       paint: {
         'circle-radius': ['tan', 1]

--- a/data/mapbox_metadata/expression_string.ts
+++ b/data/mapbox_metadata/expression_string.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const expression_string: Omit<MbStyle, 'sources'> = {
+const expression_string: MbStyle = {
   version: 8,
   name: 'Expression String',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'text-field': [
@@ -18,6 +25,8 @@ const expression_string: Omit<MbStyle, 'sources'> = {
       }
     }, {
       id: 'r1_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'text-field': [
@@ -27,6 +36,8 @@ const expression_string: Omit<MbStyle, 'sources'> = {
       }
     }, {
       id: 'r2_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'text-field': [

--- a/data/mapbox_metadata/fill_patternfill.ts
+++ b/data/mapbox_metadata/fill_patternfill.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const fillSimpleFill: Omit<MbStyle, 'sources'> = {
+const fillSimpleFill: MbStyle = {
   version: 8,
   name: 'Pattern Fill',
   sprite: 'https://testurl.com',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'fill',
       paint: {
         'fill-color': '#000000',

--- a/data/mapbox_metadata/fill_simple_outline.ts
+++ b/data/mapbox_metadata/fill_simple_outline.ts
@@ -1,10 +1,17 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const fillSimpleFillOutline: Omit<MbStyle, 'sources'> = {
+const fillSimpleFillOutline: MbStyle = {
   version: 8,
   name: 'Simple Fill With outline',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [{
     id: 'r0_sy0_st0',
+    source: 'testsource',
+    'source-layer': 'foo',
     type: 'fill',
     paint: {
       'fill-color': '#ff0000'
@@ -12,6 +19,8 @@ const fillSimpleFillOutline: Omit<MbStyle, 'sources'> = {
   },
   {
     id: 'r0_sy0_st1',
+    source: 'testsource',
+    'source-layer': 'foo',
     type: 'line',
     paint: {
       'line-opacity': 0.5,

--- a/data/mapbox_metadata/fill_simplefill.ts
+++ b/data/mapbox_metadata/fill_simplefill.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const fillSimpleFill: Omit<MbStyle, 'sources'> = {
+const fillSimpleFill: MbStyle = {
   version: 8,
   name: 'Simple Fill',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'fill',
       paint: {
         'fill-color': '#000000',

--- a/data/mapbox_metadata/icon_simpleicon.ts
+++ b/data/mapbox_metadata/icon_simpleicon.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const iconSimpleIcon: Omit<MbStyle, 'sources'> = {
+const iconSimpleIcon: MbStyle = {
   version: 8,
   name: 'Simple Icon',
   sprite: 'https://testurl.com',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'icon-image': 'poi'

--- a/data/mapbox_metadata/icon_simpleicon_mapboxapi.ts
+++ b/data/mapbox_metadata/icon_simpleicon_mapboxapi.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const iconSimpleIcon: Omit<MbStyle, 'sources'> = {
+const iconSimpleIcon: MbStyle = {
   version: 8,
   name: 'Simple Icon',
   sprite: 'mapbox://sprites/mapbox/streets-v8',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'icon-image': 'poi'

--- a/data/mapbox_metadata/icontext_symbolizer.ts
+++ b/data/mapbox_metadata/icontext_symbolizer.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const iconTextSymbolizer: Omit<MbStyle, 'sources'> = {
+const iconTextSymbolizer: MbStyle = {
   version: 8,
   name: 'icontext symbolizer',
   sprite: 'https://testurl.com',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       type: 'symbol',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'text-color': 'rgba(45, 45, 45, 1)',
       },

--- a/data/mapbox_metadata/line_patternline.ts
+++ b/data/mapbox_metadata/line_patternline.ts
@@ -1,13 +1,20 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const linePatternLine: Omit<MbStyle, 'sources'> = {
+const linePatternLine: MbStyle = {
   version: 8,
   name: 'Pattern Line',
   sprite: 'https://testurl.com',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
       type: 'line',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'line-color': '#000000',
         'line-width': 3,

--- a/data/mapbox_metadata/line_simpleline.ts
+++ b/data/mapbox_metadata/line_simpleline.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const lineSimpleLine: Omit<MbStyle, 'sources'> = {
+const lineSimpleLine: MbStyle = {
   version: 8,
   name: 'Simple Line',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
       type: 'line',
+      source: 'testsource',
+      'source-layer': 'foo',
       paint: {
         'line-color': '#000000',
         'line-width': 3,

--- a/data/mapbox_metadata/line_simpleline_basefilter.ts
+++ b/data/mapbox_metadata/line_simpleline_basefilter.ts
@@ -1,10 +1,17 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const lineSimpleLine: Omit<MbStyle, 'sources'> = {
+const lineSimpleLine: MbStyle = {
   version: 8,
   name: 'Small populated New Yorks',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [{
     id: 'r0_sy0_st0',
+    source: 'testsource',
+    'source-layer': 'foo',
     type: 'line',
     filter: ['all',
       ['==', 'NAME', 'New York'],

--- a/data/mapbox_metadata/line_simpleline_expression.ts
+++ b/data/mapbox_metadata/line_simpleline_expression.ts
@@ -1,10 +1,17 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const lineSimpleLine: Omit<MbStyle, 'sources'> = {
+const lineSimpleLine: MbStyle = {
   version: 8,
   name: 'Simple Line Filter',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [{
     id: 'r0_sy0_st0',
+    source: 'testsource',
+    'source-layer': 'foo',
     type: 'line',
     paint: {
       'line-color': '#FF0000',

--- a/data/mapbox_metadata/line_simpleline_zoom.ts
+++ b/data/mapbox_metadata/line_simpleline_zoom.ts
@@ -1,10 +1,17 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const lineSimpleLine: Omit<MbStyle, 'sources'> = {
+const lineSimpleLine: MbStyle = {
   version: 8,
   name: 'Simple Line Filter',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [{
     id: 'r0_sy0_st0',
+    source: 'testsource',
+    'source-layer': 'foo',
     type: 'line',
     minzoom: 5.5,
     maxzoom: 10,

--- a/data/mapbox_metadata/multi_rule_line_fill.ts
+++ b/data/mapbox_metadata/multi_rule_line_fill.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const multiRuleLineFill: Omit<MbStyle, 'sources'> = {
+const multiRuleLineFill: MbStyle = {
   version: 8,
   name: 'Rule Line Fill',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'line',
       paint: {
         'line-color': '#000000',
@@ -18,6 +25,8 @@ const multiRuleLineFill: Omit<MbStyle, 'sources'> = {
       }
     }, {
       id: 'r1_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'fill',
       paint: {
         'fill-color': '#000000',

--- a/data/mapbox_metadata/multi_simpleline_simplefill.ts
+++ b/data/mapbox_metadata/multi_simpleline_simplefill.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const multiSimpleLineSimpleFill: Omit<MbStyle, 'sources'> = {
+const multiSimpleLineSimpleFill: MbStyle = {
   version: 8,
   name: 'Simple Line Simple Fill',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'line',
       paint: {
         'line-color': '#000000',
@@ -18,6 +25,8 @@ const multiSimpleLineSimpleFill: Omit<MbStyle, 'sources'> = {
       }
     }, {
       id: 'r1_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'fill',
       paint: {
         'fill-color': '#000000',

--- a/data/mapbox_metadata/point_placeholderText.ts
+++ b/data/mapbox_metadata/point_placeholderText.ts
@@ -1,12 +1,19 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const pointPlaceholderText: Omit<MbStyle, 'sources'> = {
+const pointPlaceholderText: MbStyle = {
   version: 8,
   name: 'Placeholder Text',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
       type: 'symbol',
+      source: 'testsource',
+      'source-layer': 'foo',
       layout: {
         'text-field': ['format',
           'Area: ', {},

--- a/data/mapbox_metadata/point_placeholderText_simple.ts
+++ b/data/mapbox_metadata/point_placeholderText_simple.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const pointPlaceholderText: Omit<MbStyle, 'sources'> = {
+const pointPlaceholderText: MbStyle = {
   version: 8,
   name: 'Placeholder Text',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'text-field': '{River}'

--- a/data/mapbox_metadata/point_simpletext.ts
+++ b/data/mapbox_metadata/point_simpletext.ts
@@ -1,11 +1,18 @@
 import { MbStyle } from '../../src/MapboxStyleParser';
 
-const pointSimpleText: Omit<MbStyle, 'sources'> = {
+const pointSimpleText: MbStyle = {
   version: 8,
   name: 'Simple Text',
+  sources: {
+    testsource: {
+      type: 'vector'
+    }
+  },
   layers: [
     {
       id: 'r0_sy0_st0',
+      source: 'testsource',
+      'source-layer': 'foo',
       type: 'symbol',
       layout: {
         'text-field': 'River'

--- a/data/mapbox_metadata/source_layer_mapping.ts
+++ b/data/mapbox_metadata/source_layer_mapping.ts
@@ -1,0 +1,58 @@
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const sourceLayerMapping: MbStyle = {
+  version: 8,
+  name: 'SourceLayerMapping',
+  sources: {
+    first: {
+      type: 'vector'
+    }
+  },
+  layers: [
+    {
+      id: 'r0_sy0_st0',
+      source: 'first',
+      'source-layer': 'foo',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    },
+    {
+      id: 'r1_sy0_st0',
+      source: 'first',
+      'source-layer': 'bar',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    }
+  ],
+  metadata: {
+    'geostyler:ref': {
+      rules: [{
+        name: 'Simple Circle 1',
+        symbolizers: [[
+          'r0_sy0_st0'
+        ]]
+      }, {
+        name: 'Simple Circle 2',
+        symbolizers: [[
+          'r1_sy0_st0'
+        ]]
+      }]
+    }
+  }
+};
+
+export default sourceLayerMapping;

--- a/data/mapbox_metadata/source_mapping.ts
+++ b/data/mapbox_metadata/source_mapping.ts
@@ -1,0 +1,61 @@
+import { MbStyle } from '../../src/MapboxStyleParser';
+
+const sourceMapping: MbStyle = {
+  version: 8,
+  name: 'SourceMapping',
+  sources: {
+    first: {
+      type: 'vector'
+    },
+    second: {
+      type: 'vector'
+    }
+  },
+  layers: [
+    {
+      id: 'r0_sy0_st0',
+      source: 'first',
+      'source-layer': 'foo',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    },
+    {
+      id: 'r1_sy0_st0',
+      source: 'second',
+      'source-layer': 'foo',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    }
+  ],
+  metadata: {
+    'geostyler:ref': {
+      rules: [{
+        name: 'Simple Circle 1',
+        symbolizers: [[
+          'r0_sy0_st0'
+        ]]
+      }, {
+        name: 'Simple Circle 2',
+        symbolizers: [[
+          'r1_sy0_st0'
+        ]]
+      }]
+    }
+  }
+};
+
+export default sourceMapping;

--- a/data/styles/circle_simplecircle.ts
+++ b/data/styles/circle_simplecircle.ts
@@ -14,7 +14,22 @@ const circleSimpleCircle: Style = {
       strokeColor: '#FF0000',
       strokeOpacity: 0.5
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default circleSimpleCircle;

--- a/data/styles/fill_patternfill.ts
+++ b/data/styles/fill_patternfill.ts
@@ -13,7 +13,22 @@ const fillPatternFill: Style = {
         image: '/sprites/?name=poi&baseurl=' + encodeURIComponent('https://testurl.com')
       }
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default fillPatternFill;

--- a/data/styles/fill_simple_outline.ts
+++ b/data/styles/fill_simple_outline.ts
@@ -13,7 +13,22 @@ const fillSimpleFillOutline: Style = {
       outlineCap: 'butt',
       outlineJoin: 'round'
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default fillSimpleFillOutline;

--- a/data/styles/fill_simplefill.ts
+++ b/data/styles/fill_simplefill.ts
@@ -9,7 +9,22 @@ const fillSimpleFill: Style = {
       color: '#000000',
       opacity: 1
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default fillSimpleFill;

--- a/data/styles/gs_expression_case.ts
+++ b/data/styles/gs_expression_case.ts
@@ -86,7 +86,22 @@ const gs_expression_case: Style = {
       radius: 12,
       fillOpacity: 0.6
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default gs_expression_case;

--- a/data/styles/gs_expression_decisions.ts
+++ b/data/styles/gs_expression_decisions.ts
@@ -228,7 +228,22 @@ const gs_expression_decisions: Style = {
         ]
       }
     }]
-  },]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+      },
+      sourceLayerMapping: {
+        foo: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+      }
+    }
+  }
 };
 
 export default gs_expression_decisions;

--- a/data/styles/gs_expression_lookup.ts
+++ b/data/styles/gs_expression_lookup.ts
@@ -22,7 +22,22 @@ const gs_expression_lookup: Style = {
         args: ['peter', 0, 2]
       }
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0, 1]
+      },
+      sourceLayerMapping: {
+        foo: [0, 1]
+      }
+    }
+  }
 };
 
 export default gs_expression_lookup;

--- a/data/styles/gs_expression_math.ts
+++ b/data/styles/gs_expression_math.ts
@@ -222,7 +222,22 @@ const gs_expression_math: Style = {
         args: [1]
       }
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+      },
+      sourceLayerMapping: {
+        foo: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+      }
+    }
+  }
 };
 
 export default gs_expression_math;

--- a/data/styles/gs_expression_property.ts
+++ b/data/styles/gs_expression_property.ts
@@ -21,7 +21,22 @@ const gs_expression_property: Style = {
       strokeColor: '#FF0000',
       strokeOpacity: 0.5
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default gs_expression_property;

--- a/data/styles/gs_expression_string.ts
+++ b/data/styles/gs_expression_string.ts
@@ -30,7 +30,22 @@ const gs_expression_string: Style = {
         args: ['peter']
       }
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0, 1, 2]
+      },
+      sourceLayerMapping: {
+        foo: [0, 1, 2]
+      }
+    }
+  }
 };
 
 export default gs_expression_string;

--- a/data/styles/icon_simpleicon.ts
+++ b/data/styles/icon_simpleicon.ts
@@ -8,7 +8,22 @@ const iconSimpleIcon: Style = {
       kind: 'Icon',
       image: '/sprites/?name=poi&baseurl=' + encodeURIComponent('https://testurl.com')
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default iconSimpleIcon;

--- a/data/styles/icon_simpleicon_mapboxapi.ts
+++ b/data/styles/icon_simpleicon_mapboxapi.ts
@@ -8,7 +8,22 @@ const iconSimpleIcon: Style = {
       kind: 'Icon',
       image: '/sprites/?name=poi&baseurl=' + encodeURIComponent('https://api.mapbox.com/sprites/mapbox/streets-v8')
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default iconSimpleIcon;

--- a/data/styles/line_patternline.ts
+++ b/data/styles/line_patternline.ts
@@ -16,7 +16,22 @@ const linePatternLine: Style = {
         image: '/sprites/?name=poi&baseurl=' + encodeURIComponent('https://testurl.com')
       }
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default linePatternLine;

--- a/data/styles/line_simpleline.ts
+++ b/data/styles/line_simpleline.ts
@@ -12,7 +12,22 @@ const lineSimpleLine: Style = {
       cap: 'round',
       join: 'miter'
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default lineSimpleLine;

--- a/data/styles/line_simpleline_basefilter.ts
+++ b/data/styles/line_simpleline_basefilter.ts
@@ -21,7 +21,22 @@ const lineSimpleLine: Style = {
       color: '#FF0000',
       width: 3
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default lineSimpleLine;

--- a/data/styles/line_simpleline_expression.ts
+++ b/data/styles/line_simpleline_expression.ts
@@ -12,7 +12,22 @@ const lineSimpleLine: Style = {
         name: 'random'
       }
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default lineSimpleLine;

--- a/data/styles/line_simpleline_zoom.ts
+++ b/data/styles/line_simpleline_zoom.ts
@@ -13,7 +13,22 @@ const lineSimpleLine: Style = {
       color: '#FF0000',
       width: 5
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default lineSimpleLine;

--- a/data/styles/multi_rule_line_fill.ts
+++ b/data/styles/multi_rule_line_fill.ts
@@ -20,7 +20,22 @@ const multiRuleLineFill: Style = {
       color: '#000000',
       opacity: 1
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0, 1]
+      },
+      sourceLayerMapping: {
+        foo: [0, 1]
+      }
+    }
+  }
 };
 
 export default multiRuleLineFill;

--- a/data/styles/multi_simpleline_simplefill.ts
+++ b/data/styles/multi_simpleline_simplefill.ts
@@ -19,7 +19,22 @@ const multiSimpleLineSimpleFill: Style = {
       color: '#000000',
       opacity: 1
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0, 1]
+      },
+      sourceLayerMapping: {
+        foo: [0, 1]
+      }
+    }
+  }
 };
 
 export default multiSimpleLineSimpleFill;

--- a/data/styles/point_placeholderText.ts
+++ b/data/styles/point_placeholderText.ts
@@ -10,7 +10,22 @@ const pointPlaceholderText: Style = {
       color: '#000000',
       opacity: 1
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default pointPlaceholderText;

--- a/data/styles/point_placeholderText_simple.ts
+++ b/data/styles/point_placeholderText_simple.ts
@@ -10,7 +10,22 @@ const pointPlaceholderText: Style = {
       color: '#000000',
       opacity: 1
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default pointPlaceholderText;

--- a/data/styles/point_simpletext.ts
+++ b/data/styles/point_simpletext.ts
@@ -10,7 +10,22 @@ const pointSimpleText: Style = {
       color: '#000000',
       opacity: 1
     }]
-  }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
+    }
+  }
 };
 
 export default pointSimpleText;

--- a/data/styles/source_layer_mapping.ts
+++ b/data/styles/source_layer_mapping.ts
@@ -1,0 +1,48 @@
+import { Style } from 'geostyler-style';
+
+const sourceLayerMapping: Style = {
+  name: 'SourceLayerMapping',
+  rules: [{
+    name: 'Simple Circle 1',
+    symbolizers: [{
+      kind: 'Mark',
+      wellKnownName: 'circle',
+      color: '#000000',
+      radius: 5,
+      fillOpacity: 1,
+      strokeWidth: 2,
+      strokeColor: '#FF0000',
+      strokeOpacity: 0.5
+    }]
+  }, {
+    name: 'Simple Circle 2',
+    symbolizers: [{
+      kind: 'Mark',
+      wellKnownName: 'circle',
+      color: '#000000',
+      radius: 5,
+      fillOpacity: 1,
+      strokeWidth: 2,
+      strokeColor: '#FF0000',
+      strokeOpacity: 0.5
+    }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        first: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        first: [0, 1]
+      },
+      sourceLayerMapping: {
+        foo: [0],
+        bar: [1]
+      }
+    }
+  }
+};
+
+export default sourceLayerMapping;

--- a/data/styles/source_mapping.ts
+++ b/data/styles/source_mapping.ts
@@ -1,0 +1,51 @@
+import { Style } from 'geostyler-style';
+
+const sourceMapping: Style = {
+  name: 'SourceMapping',
+  rules: [{
+    name: 'Simple Circle 1',
+    symbolizers: [{
+      kind: 'Mark',
+      wellKnownName: 'circle',
+      color: '#000000',
+      radius: 5,
+      fillOpacity: 1,
+      strokeWidth: 2,
+      strokeColor: '#FF0000',
+      strokeOpacity: 0.5
+    }]
+  }, {
+    name: 'Simple Circle 2',
+    symbolizers: [{
+      kind: 'Mark',
+      wellKnownName: 'circle',
+      color: '#000000',
+      radius: 5,
+      fillOpacity: 1,
+      strokeWidth: 2,
+      strokeColor: '#FF0000',
+      strokeOpacity: 0.5
+    }]
+  }],
+  metadata: {
+    'mapbox:ref': {
+      sources: {
+        first: {
+          type: 'vector'
+        },
+        second: {
+          type: 'vector'
+        }
+      },
+      sourceMapping: {
+        first: [0],
+        second: [1]
+      },
+      sourceLayerMapping: {
+        foo: [0, 1]
+      }
+    }
+  }
+};
+
+export default sourceMapping;

--- a/data/styles_metadata/icontext_symbolizer.ts
+++ b/data/styles_metadata/icontext_symbolizer.ts
@@ -23,10 +23,21 @@ const iconTextSymbolizer: Style = {
   ],
   metadata: {
     'mapbox:ref': {
+      sources: {
+        testsource: {
+          type: 'vector'
+        }
+      },
       splitSymbolizers: [{
         rule: 0,
         symbolizers: [0, 1]
-      }]
+      }],
+      sourceMapping: {
+        testsource: [0]
+      },
+      sourceLayerMapping: {
+        foo: [0]
+      }
     }
   }
 };

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -51,6 +51,12 @@ import mb_point_placeholdertext_simple_metadata from '../data/mapbox_metadata/po
 import icontext_symbolizer_metadata from '../data/styles_metadata/icontext_symbolizer';
 import mb_icontext_symbolizer from '../data/mapbox/icontext_symbolizer';
 import mb_icontext_symbolizer_metadata from '../data/mapbox_metadata/icontext_symbolizer';
+import source_mapping from '../data/styles/source_mapping';
+import mb_source_mapping from '../data/mapbox/source_mapping';
+import mb_source_mapping_metadata from '../data/mapbox_metadata/source_mapping';
+import source_layer_mapping from '../data/styles/source_layer_mapping';
+import mb_source_layer_mapping from '../data/mapbox/source_layer_mapping';
+import mb_source_layer_mapping_metadata from '../data/mapbox_metadata/source_layer_mapping';
 import { CustomLayerInterface } from 'mapbox-gl';
 import { AnyLayer } from 'mapbox-gl';
 
@@ -195,6 +201,18 @@ describe('MapboxStyleParser implements StyleParser', () => {
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(icontext_symbolizer_metadata);
     });
+
+    it('can keep track of a mapbox style sources', async () => {
+      const { output: geoStylerStyle } = await styleParser.readStyle(mb_source_mapping);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(source_mapping);
+    });
+
+    it('can keep track of a mapbox style layer source', async () => {
+      const { output: geostylerStyle } = await styleParser.readStyle(mb_source_layer_mapping);
+      expect(geostylerStyle).toBeDefined();
+      expect(geostylerStyle).toEqual(source_layer_mapping);
+    });
   });
 
   describe('#writeStyle', () => {
@@ -303,6 +321,18 @@ describe('MapboxStyleParser implements StyleParser', () => {
       const { output: mbStyle } = await styleParser.writeStyle(icontext_symbolizer_metadata);
       expect(mbStyle).toBeDefined();
       expect(mbStyle).toEqual(mb_icontext_symbolizer_metadata);
+    });
+
+    it('can properly resolve the source mapping', async () => {
+      const { output: mbStyle } = await styleParser.writeStyle(source_mapping);
+      expect(mbStyle).toBeDefined();
+      expect(mbStyle).toEqual(mb_source_mapping_metadata);
+    });
+
+    it('can properly resolve the source layer mapping', async () => {
+      const { output: mbStyle } = await styleParser.writeStyle(source_layer_mapping);
+      expect(mbStyle).toBeDefined();
+      expect(mbStyle).toEqual(mb_source_layer_mapping_metadata);
     });
   });
 });


### PR DESCRIPTION
This keeps track of the `source` and `layer-source` properties of a mapbox style layer. Through this, we are able to keep the references to sources and source-layers to/from rules when parsing multiple times. This also enables the assignment of geostyler rules to specific sources, which is needed when creating new styling instructions that were not yet present in a mapbox style.

BREAKING CHANGE: This makes the previously omitted `source` property of a mapbox style required. So we are actually conformant with the mapbox style specification in that regard. This breaking change probably affected mostly our tests, which were adjusted.

depends on https://github.com/geostyler/geostyler-mapbox-parser/pull/287