### PR TITLE
fix: update resolutions to levels 0-24

### DIFF
--- a/src/Util/MapboxStyleUtil.ts
+++ b/src/Util/MapboxStyleUtil.ts
@@ -10,7 +10,7 @@ class MapboxStyleUtil {
     // This simplyfies working with zoom levels but might lead to unexpected
     // behaviour.
     resolutions.push(res * 2);
-    for (res; resolutions.length < 22; res /= 2) {
+    for (res; resolutions.length <= 24; res /= 2) {
       resolutions.push(res);
     }
     return resolutions;


### PR DESCRIPTION
This updates the resolutions to levels 0-24 matching the WebMercatorQuad resolutions: https://raw.githubusercontent.com/opengeospatial/2D-Tile-Matrix-Set/master/registry/json/WebMercatorQuad.json