### PR TITLE
fix: preserve visibility in line symbolizer for fill outline

### DIFF
--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -1309,6 +1309,7 @@ export class MapboxStyleParser implements StyleParser<Omit<MbStyle, 'sources'>> 
     symbolizerClone = structuredClone(symbolizer as FillSymbolizer);
     const lineSymbolizer: LineSymbolizer = {
       kind: 'Line',
+      visibility: symbolizerClone?.visibility,
       color: symbolizerClone?.outlineColor,
       opacity: symbolizerClone?.outlineOpacity,
       width: symbolizerClone?.outlineWidth,


### PR DESCRIPTION
Fill outline lost the visibility property when parsing from fill symbolizer.
This should set the visibility prop if set in base symbolizer.