### PR TITLE
Fix: preserve outline dash array

### DIFF
--- a/data/mapbox/fill_simple_outline.ts
+++ b/data/mapbox/fill_simple_outline.ts
@@ -25,7 +25,8 @@ const fillSimpleFillOutline: MbStyle = {
     paint: {
       'line-opacity': 0.5,
       'line-color': '#00ff00',
-      'line-width': 2
+      'line-width': 2,
+      'line-dasharray': [13, 37]
     },
     layout: {
       'line-cap': 'butt',

--- a/data/mapbox_metadata/fill_simple_outline.ts
+++ b/data/mapbox_metadata/fill_simple_outline.ts
@@ -25,7 +25,8 @@ const fillSimpleFillOutline: MbStyle = {
     paint: {
       'line-opacity': 0.5,
       'line-color': '#00ff00',
-      'line-width': 2
+      'line-width': 2,
+      'line-dasharray': [13, 37]
     },
     layout: {
       'line-cap': 'butt',

--- a/data/styles/fill_simple_outline.ts
+++ b/data/styles/fill_simple_outline.ts
@@ -11,7 +11,8 @@ const fillSimpleFillOutline: Style = {
       outlineWidth: 2,
       outlineOpacity: 0.5,
       outlineCap: 'butt',
-      outlineJoin: 'round'
+      outlineJoin: 'round',
+      outlineDasharray: [13, 37]
     }]
   }],
   metadata: {

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -736,6 +736,7 @@ export class MapboxStyleParser implements StyleParser<Omit<MbStyle, 'sources'>> 
           merged.outlineCap = lineSymbolizer.cap;
           merged.outlineJoin = lineSymbolizer.join;
           merged.outlineWidth = lineSymbolizer.width;
+          merged.outlineDasharray = lineSymbolizer.dasharray;
         } else {
           throw new Error(`Trying to merge two symbolizers of different kinds: ${s1.kind}, ${s2.kind}`);
         }
@@ -1315,6 +1316,7 @@ export class MapboxStyleParser implements StyleParser<Omit<MbStyle, 'sources'>> 
       width: symbolizerClone?.outlineWidth,
       join: symbolizerClone?.outlineJoin,
       cap: symbolizerClone?.outlineCap,
+      dasharray: symbolizerClone?.outlineDasharray,
     };
 
     const outlineLayer: Omit<LineLayer, 'id'> = {


### PR DESCRIPTION
Whereever something handles outlineWidth (2 places), it should also handle outlineDasharray (missing in 2 places).

Handling it is simple as the array itself doesn't need conversion.